### PR TITLE
[BUGFIX] Catch expired password reponses from crowd

### DIFF
--- a/Packages/Application/Neos.CrowdClient/Classes/Neos/CrowdClient/Domain/Service/CrowdClient.php
+++ b/Packages/Application/Neos.CrowdClient/Classes/Neos/CrowdClient/Domain/Service/CrowdClient.php
@@ -124,6 +124,8 @@ class CrowdClient {
 						return NULL;
 					case 'USER_NOT_FOUND':
 						return NULL;
+					case 'EXPIRED_CREDENTIAL':
+						return NULL;
 				}
 			}
 			throw $e;


### PR DESCRIPTION
This change adds the expired password response from
crowd to the list of failed authentication exceptions.